### PR TITLE
File Generation: Enable Failure Notifications Only

### DIFF
--- a/config/ioi-city-mall-sales-file.php
+++ b/config/ioi-city-mall-sales-file.php
@@ -64,7 +64,7 @@ return [
     'notifications' => [
         'name' => env('IOI_CITY_MALL_SALES_FILE_NOTIFICATION_NAME'), // Receiver's Name
         'email' => env('IOI_CITY_MALL_SALES_FILE_NOTIFICATION_EMAIL'), // Receiver's E-mail
-        'enable_failure_notifications_only' => env('IOI_CITY_MALL_SALES_FILE_ENABLE_FAILURE_NOTIFICATIONS_ONLY'), // This flag determines whether only failure notifications should be received. Set to 'true' to receive only failure notifications, 'false' for all notifications.
+        'enable_failure_notifications_only' => env('IOI_CITY_MALL_SALES_FILE_ENABLE_FAILURE_NOTIFICATIONS_ONLY', false), // This flag determines whether only failure notifications should be received. Set to 'true' to receive only failure notifications, 'false' for all notifications.
     ],
 
     /*

--- a/config/ioi-city-mall-sales-file.php
+++ b/config/ioi-city-mall-sales-file.php
@@ -64,6 +64,7 @@ return [
     'notifications' => [
         'name' => env('IOI_CITY_MALL_SALES_FILE_NOTIFICATION_NAME'), // Receiver's Name
         'email' => env('IOI_CITY_MALL_SALES_FILE_NOTIFICATION_EMAIL'), // Receiver's E-mail
+        'enable_failure_notifications_only' => env('IOI_CITY_MALL_SALES_FILE_ENABLE_FAILURE_NOTIFICATIONS_ONLY'), // This flag determines whether only failure notifications should be received. Set to 'true' to receive only failure notifications, 'false' for all notifications.
     ],
 
     /*

--- a/src/Commands/SalesFileGenerationCommand.php
+++ b/src/Commands/SalesFileGenerationCommand.php
@@ -75,7 +75,7 @@ class SalesFileGenerationCommand extends Command
 
             Log::channel($logChannel)->info($message);
 
-            if (! empty($notificationConfig['email'])) {
+            if (! empty($notificationConfig['email']) && ! $notificationConfig['enable_failure_notifications_only']) {
                 Notification::route('mail', $notificationConfig['email'])->notify(new SalesFileGenerationNotification(status: 'success', messages: "Sales File Generated Successfully for the date of {$date} & has been stored to specified disk"));
             }
 
@@ -112,9 +112,11 @@ class SalesFileGenerationCommand extends Command
             'notifications' => ['required'],
             'notifications.name' => ['nullable'],
             'notifications.email' => ['nullable', 'email'],
+            'notifications.enable_failure_notifications_only' => ['required', 'boolean'],
             'log_channel_for_file_generation' => ['required'],
         ], [
             'notifications.email.email' => 'Please set valid e-mail in config notifications array',
+            'notifications.enable_failure_notifications_only.required' => 'Please indicate whether to enable only failure notifications',
             'log_channel_for_file_generation.required' => 'Please set the log channel for file generation',
         ]);
 

--- a/tests/SalesFileGenerationCommandTest.php
+++ b/tests/SalesFileGenerationCommandTest.php
@@ -39,6 +39,20 @@ describe('Configuration Checks', function () {
         Notification::assertNothingSent();
     });
 
+    it('will not execute the command if notifications.enable_failure_notifications_only is not present', function () {
+
+        config()->set('ioi-city-mall-sales-file.notifications', [
+            'email' => 'some@email.com',
+        ]);
+
+        Artisan::call('generate:ioi-city-mall-sales-files');
+
+        expect(Artisan::output())->toContain('Please indicate whether to enable only failure notifications');
+
+        Notification::assertNothingSent();
+
+    });
+
 });
 
 describe('Configuration Checks with Notifications', function () {
@@ -390,6 +404,28 @@ describe('Informational Scenarios', function () {
     it('file generation works even if the notification config is not set.', function () {
         config()->set('ioi-city-mall-sales-file.notifications.email', null);
         config()->set('ioi-city-mall-sales-file.notifications.name', null);
+
+        $stores = sampleStoresData1();
+
+        $this->serviceMock->shouldReceive('storesList')->andReturn(collect($stores));
+
+        $this->serviceMock->shouldReceive('salesData')->andReturn(collect([]));
+
+        Artisan::call('generate:ioi-city-mall-sales-files');
+
+        $output = Artisan::output();
+
+        expect($output)->toContain('Sales files generated successfully.');
+
+        Notification::assertNothingSent();
+    });
+
+    it('does not send success notification when enable_failure_notifications_only is true', function () {
+        config()->set('ioi-city-mall-sales-file.notifications', [
+            'name' => 'Pest Test',
+            'email' => 'test@testmail.com',
+            'enable_failure_notifications_only' => true,
+        ]);
 
         $stores = sampleStoresData1();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,7 @@ class TestCase extends Orchestra
     {
         config()->set('ioi-city-mall-sales-file.notifications.name', 'Admin');
         config()->set('ioi-city-mall-sales-file.notifications.email', 'admin@example.com');
+        config()->set('ioi-city-mall-sales-file.notifications.enable_failure_notifications_only', false);
         config()->set('database.default', 'testing');
     }
 }


### PR DESCRIPTION
- Task Link: [Notion Link](https://www.notion.so/IOI-and-TRX-receive-only-failure-notifications-5b802ce0dbb64b20ad139445a6604ce9)

- Description: This PR Contains code related to ```Enable Failure Notifications Only``` for file generation. The sub-sequent PR will contain for file upload.


--------------------------------

Please take a minute and verify each of the things below before requesting for a review of your PR.

### Q & A
- [x] I have added new tests and/or updated existing tests as applicable.
- [x] I have done the manual testing to make sure that the coding is done correctly as per the requirements in the Notion task.

### Documentation
- [x] I have updated the Postman API details and Notion documentation as applicable

### Security
- [x] I have added validation rules for all the data/inputs from the users/browsers.
~- [] I have added/used respective permissions to the new routes/API endpoints for authorization.~

### Code quality/maintainability
- [x] I have run the Code Quality command.
- [x] I haven't used magic numbers anywhere in the code. constants/enums are used instead.
- [x] I have divided all the logic into respective domains and no code crosses its domain boundaries.
