### PR TITLE
File Upload: Enable Failure Notifications Only

### DIFF
--- a/src/Commands/SalesFileUploadCommand.php
+++ b/src/Commands/SalesFileUploadCommand.php
@@ -74,7 +74,7 @@ class SalesFileUploadCommand extends Command
 
                 Log::channel($logChannel)->info($message);
 
-                if (! empty($notificationConfig['email'])) {
+                if (! empty($notificationConfig['email'] && ! $notificationConfig['enable_failure_notifications_only'])) {
                     Notification::route('mail', $notificationConfig['email'])->notify(new SalesFileUploadNotification(status: 'success', messages: 'Sales File Uploaded Successfully to the SFTP Server'));
                 }
 
@@ -82,7 +82,7 @@ class SalesFileUploadCommand extends Command
             } else {
                 $message = 'No sales files found for upload.';
 
-                if (! empty($notificationConfig['email'])) {
+                if (! empty($notificationConfig['email']) && ! $notificationConfig['enable_failure_notifications_only']) {
                     Notification::route('mail', $notificationConfig['email'])->notify(new SalesFileUploadNotification(status: 'info', messages: $message));
                 }
 
@@ -121,9 +121,11 @@ class SalesFileUploadCommand extends Command
             'notifications' => ['required'],
             'notifications.name' => ['nullable'],
             'notifications.email' => ['nullable', 'email'],
+            'notifications.enable_failure_notifications_only' => ['required', 'boolean'],
             'log_channel_for_file_upload' => ['required'],
         ], [
             'notifications.email.email' => 'Please set valid e-mail in config notifications array',
+            'notifications.enable_failure_notifications_only.required' => 'Please indicate whether to enable only failure notifications',
             'log_channel_for_file_upload.required' => 'Please set the log channel for file upload',
         ]);
 

--- a/tests/SalesFileUploadCommandTest.php
+++ b/tests/SalesFileUploadCommandTest.php
@@ -159,7 +159,7 @@ describe('Success Scenarios', function () {
         );
     });
 
-    it('uploads sales files to SFTP server with enabled failure notifications only', function () {
+    it('uploads sales files to SFTP server when only failure notifications are enabled', function () {
 
         $storage = Storage::disk('local');
 

--- a/tests/SalesFileUploadCommandTest.php
+++ b/tests/SalesFileUploadCommandTest.php
@@ -159,7 +159,7 @@ describe('Success Scenarios', function () {
         );
     });
 
-    it('uploads sales files to SFTP server when only failure notifications are enabled', function () {
+    it('uploads sales files to SFTP server without sending success notification when enable_failure_notifications_only is true', function () {
 
         $storage = Storage::disk('local');
 


### PR DESCRIPTION
- Task Link: [Notion Link](https://www.notion.so/IOI-and-TRX-receive-only-failure-notifications-5b802ce0dbb64b20ad139445a6604ce9)

- Description: This PR Contains code related to ```Enable Failure Notifications Only``` for file upload. 


--------------------------------

Please take a minute and verify each of the things below before requesting for a review of your PR.

### Q & A
- [x] I have added new tests and/or updated existing tests as applicable.
- [x] I have done the manual testing to make sure that the coding is done correctly as per the requirements in the Notion task.

### Documentation
- [x] I have updated the Postman API details and Notion documentation as applicable

### Security
- [x] I have added validation rules for all the data/inputs from the users/browsers.
~- [] I have added/used respective permissions to the new routes/API endpoints for authorization.~

### Code quality/maintainability
- [x] I have run the Code Quality command.
- [x] I haven't used magic numbers anywhere in the code. constants/enums are used instead.
- [x] I have divided all the logic into respective domains and no code crosses its domain boundaries.
